### PR TITLE
✨ Add custom event type handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## V0.2.0
+
+Update `custom_event_subtype_handlers` to `custom_message_subtype_handlers` and add support for `custom_event_type_handlers`. This is a breaking change since we rename the field that was previously used. To fix, update any calls from `custom_event_subtype_handlers` to `custom_message_subtype_handlers` and you should be good to go.
+
 ## V0.1.5
 
 Update how the `bot_id` is set in the handler configuration. You can disable the slack auth test (which is used to obtain the bot_id) by setting `SLACK_AUTH_SKIP=1` in your environment variables. If you are running in a Rails environment other than production, development or staging and would like to use the bot for real requests, you can trigger a manual auth test by calling `Slackify.configuration.handlers.bot_auth_test`. Gemfile.lock was removed.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Slackify is a gem that allows to build slackbots on Rails using the [Event API](
     * [Plain messages](#handling-plain-messages)
     * [Interactive messages](#handling-interactive-messages)
     * [Slash Command](#handling-slash-commands)
-    * [Custom handler for event subtypes](#custom-handler-for-event-subtypes)
+    * [Custom handler for message subtypes](#custom-handler-for-message-subtypes)
+    * [Custom handler for event types](#custom-handler-for-event-types)
     * [Custom unhandled handler](#custom-unhandled-handler)
   * [Slack client](#slack-client)
     * [Sending a simple message](#sending-a-simple-message)
@@ -85,17 +86,29 @@ class DummyHandler < Slackify::Handlers::Base
 end
 ```
 
-### Custom handler for event subtypes
+### Custom handler for message subtypes
 
-If you wish to add more functionalities to your bot, you can specify define new behaviours for different event subtypes. You can specify a hash with the event subtype as a key and the handler class as the value. Slackify will call `.handle_event` on your class and pass the controller params as parameters.
+If you wish to add more functionalities to your bot, you can specify define new behaviours for different message subtypes. You can specify a hash with the event subtype as a key and the handler class as the value. Slackify will call `.handle_event` on your class and pass the controller params as parameters.
 
 ```ruby
-Slackify.configuration.custom_event_subtype_handlers = {
+Slackify.configuration.custom_message_subtype_handlers = {
+  file_share: MessageImageHandler
+}
+```
+
+In this example, all message of subtype `file_share` will be sent to the `MessageImageHandler` class.
+
+### Custom handler for event types
+
+If you wish to add more functionalities to your bot, you can specify define new behaviours for different event types. You can specify a hash with the event type as a key and the handler class as the value. Slackify will call `.handle_event` on your class and pass the controller params as parameters.
+
+```ruby
+Slackify.configuration.custom_event_type_handlers = {
   file_share: ImageHandler
 }
 ```
 
-In this example, all events of subtype `file_share` will be sent to the `ImageHandler` class.
+In this example, all events of type `file_share` will be sent to the `ImageHandler` class.
 
 ### Custom unhandled handler
 
@@ -223,7 +236,7 @@ Slackify.load_handlers
 ```ruby
 # config/initializers/slackify.rb
 Slackify.load_handlers
-Slackify.configuration.custom_event_subtype_handlers = {
+Slackify.configuration.custom_message_subtype_handlers = {
   file_share: ImageHandler,
   channel_join: JoinHandler,
   ...

--- a/lib/slackify/configuration.rb
+++ b/lib/slackify/configuration.rb
@@ -4,7 +4,7 @@ require 'slack'
 
 module Slackify
   class Configuration
-    attr_reader :custom_event_subtype_handlers, :slack_bot_token, :unhandled_handler
+    attr_reader :custom_message_subtype_handlers, :slack_bot_token, :unhandled_handler, :custom_event_type_handlers
     attr_accessor :handlers, :slack_secret_token, :slack_client
 
     def initialize
@@ -12,7 +12,8 @@ module Slackify
       @slack_secret_token = nil
       @handlers = nil
       @slack_client = nil
-      @custom_event_subtype_handlers = {}
+      @custom_message_subtype_handlers = {}
+      @custom_event_type_handlers = {}
       @unhandled_handler = Handlers::UnhandledHandler
     end
 
@@ -32,8 +33,12 @@ module Slackify
       @slack_client = Slack::Web::Client.new(token: token).freeze
     end
 
-    def custom_event_subtype_handlers=(event_subtype_hash)
-      @custom_event_subtype_handlers = event_subtype_hash.with_indifferent_access
+    def custom_message_subtype_handlers=(event_subtype_hash)
+      @custom_message_subtype_handlers = event_subtype_hash.with_indifferent_access
+    end
+
+    def custom_event_type_handlers=(event_type_hash)
+      @custom_event_type_handlers = event_type_hash.with_indifferent_access
     end
   end
 end

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'slackify'
-  s.version     = '0.1.5'
-  s.date        = '2019-09-11'
+  s.version     = '0.2.0'
+  s.date        = '2019-12-11'
   s.summary     = 'Slackbot framework for Rails using the Events API'
   s.description = 'Slackbot framework for Rails using the Events API. Supports events, interactive messages and slash commands.'
   s.authors     = ['Justin Leger', 'Michel Chatmajian']


### PR DESCRIPTION
Update `custom_event_subtype_handlers` to `custom_message_subtype_handlers` and add support for `custom_event_type_handlers`. This is a breaking change since we rename the field that was previously used. To fix, update any calls from `custom_event_subtype_handlers` to `custom_message_subtype_handlers` and you should be good to go.