### PR TITLE
Handle named parameters (and some code/error cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build-iPhoneSimulator/
 /vendor/bundle
 /lib/bundler/man/
 .rvmrc
+
+.byebug_history

--- a/README.md
+++ b/README.md
@@ -3,23 +3,25 @@
 Slackify is a gem that allows to build slackbots on Rails using the [Event API](https://api.slack.com/events-api) from Slack.
 
 ## Table of Contents
-* [How does it work](#how-does-it-work)
-  * [Handlers](#handlers)
-    * [Plain messages](#handling-plain-messages)
-    * [Interactive messages](#handling-interactive-messages)
-    * [Slash Command](#handling-slash-commands)
-    * [Custom handler for message subtypes](#custom-handler-for-message-subtypes)
-    * [Custom handler for event types](#custom-handler-for-event-types)
-    * [Custom unhandled handler](#custom-unhandled-handler)
-  * [Slack client](#slack-client)
-    * [Sending a simple message](#sending-a-simple-message)
-    * [Sending an interactive message](#sending-an-interactive-message)
-  * [Slack 3 second reply window](#slack-3-seconds-reply-window)
-* [How to run your own slackify](#how-to-run-your-own-slackify)
-  * [Initial Setup](#initial-setup)
-  * [Slack Setup](#slack-setup)
+
+- [How does it work](#how-does-it-work)
+  - [Handlers](#handlers)
+    - [Plain messages](#handling-plain-messages)
+    - [Interactive messages](#handling-interactive-messages)
+    - [Slash Command](#handling-slash-commands)
+    - [Custom handler for message subtypes](#custom-handler-for-message-subtypes)
+    - [Custom handler for event types](#custom-handler-for-event-types)
+    - [Custom unhandled handler](#custom-unhandled-handler)
+  - [Slack client](#slack-client)
+    - [Sending a simple message](#sending-a-simple-message)
+    - [Sending an interactive message](#sending-an-interactive-message)
+  - [Slack 3 second reply window](#slack-3-seconds-reply-window)
+- [How to run your own slackify](#how-to-run-your-own-slackify)
+  - [Initial Setup](#initial-setup)
+  - [Slack Setup](#slack-setup)
 
 # How does it work
+
 The core logic of the bot resides in its handlers. When the app starts, a list of handler gets initialized from a config file (`config/handlers.yml`). This initializes all the plain message handlers. Out of the box, the application supports three types of events
 
 1. [Plain messages](#handling-plain-messages)
@@ -27,19 +29,19 @@ The core logic of the bot resides in its handlers. When the app starts, a list o
 3. [Slash Command](#handling-slash-commands)
 
 ## Handlers
+
 ### Handling plain messages
+
 These are the basic handlers. They use a regex to identify if they should be called. When a message event gets sent to the bots, the slack controller sends the message to the list of handlers. The message will be checked against the regex of every handler until there is a match. When there is a match, the handler will get called with all the parameters provided by slack. If no handler matches the command, the unhandled handler will be called instead.
 
 Those handlers are configured via the `config/handlers.yml` configuration file. Let's dissect the configuration of a handler.
 
 ```yaml
--
-  repeat_handler:
+- repeat_handler:
     commands:
-      -
-        name: Repeat
+      - name: Repeat
         description: "`repeat [sentence]`: Repeats the sentence you wrote"
-        regex: !ruby/regexp '/^repeat (?<sentence>.+)/i'
+        regex: !ruby/regexp "/^repeat (?<sentence>.+)/i"
         action: repeat
 ```
 
@@ -66,9 +68,11 @@ To add a new handler, you can add a new file under `app/handlers/` and start add
 **Note:** The regex supports [named capture](https://www.regular-expressions.info/named.html). In this example, we have a name example of `sentence`. When the handler command will be called, a key in the parameter hash will be added: `command_arguments`. This key will point to a hash of the capture name and value. In this case, `command_arguments => {sentence: "the sentence you wrote"}`
 
 ### Handling interactive messages
+
 When sending an interactive message to a user, slack let's you define the `callback_id`. The app uses the callback id to select the proper handler for the message that was sent. The callback id must follow the given format: `class_name#method_name`. For instance if you set the callback id to `repeat_handler#repeat`, then `RepeatHandler#repeat` will be called. Adding new handlers does not require to update the `config/handlers.yml` configuration. You only need to update the callback id to define the proper handler to be used when you send an interactive message.
 
 ### Handling slash commands
+
 The code also has an example of a slash command and its handler (`slash_handler.rb`). To add a command on the bot, head to you app configuration on https://api.slack.com/apps and navigate to Slack Commands using the sidebar. Create a new one. The important part is to set the path properly. To bind with the demo handler, you would need to setup the path like this: `/slackify/slash/slash_handler/example_slash`. The format is `/slackify/slash/[handler_name]/[action_name]`. An app shouldn't have many slash commands. Keep in mind that adding a slash command means that the whole organization will see it.
 
 You will need to whitelist the method in the handler to indicate it can be used as a slash command using `allow_slash_method`
@@ -78,7 +82,7 @@ class DummyHandler < Slackify::Handlers::Base
   allow_slash_method :slash_command
 
   class << self
-    
+
     def slash_command(_params)
       "dummy_handler slash_command() was called"
     end
@@ -134,18 +138,21 @@ end
 ```
 
 ## Slack client
+
 In order to send messages, the [slack ruby client gem](https://github.com/slack-ruby/slack-ruby-client) was used. You can send plain text messages, images and interactive messages. Since the bot was envisioned being more repsonsive than proactive, the client was made available for handlers to call using the `slack_client` method. If you wish to send messages outside of handlers, you can get the slack client by calling `Slackify.configuration.slack_client`
 
 ### Sending a simple message
+
 ```ruby
 slack_client.chat_postMessage(channel: 'MEMBER ID OR CHANNEL ID', text: 'Hello World', as_user: true)
 ```
 
 ### Sending an interactive message
+
 ```ruby
 slack_client.chat_postMessage(
-  channel: 'MEMBER ID OR CHANNEL ID', 
-  as_user: true, 
+  channel: 'MEMBER ID OR CHANNEL ID',
+  as_user: true,
   attachments: [{
     "fallback": "Would you recommend it to customers?",
     "title": "Would you recommend it to customers?",
@@ -171,10 +178,13 @@ slack_client.chat_postMessage(
 ```
 
 ## Slack 3 seconds reply window
+
 Slack introduced a [3 seconds reply window](https://api.slack.com/messaging/interactivity#response) for interactive messages. That means that if you reply to an interactive message or slash command event with a json, slack will show either update the attachment or send a new one without having to use `chat_postMessage`. If you wish to use this feature with Slackify, you only need to return either a json of an attachment or a plain text string when you handler method is called. **Your method should always return `nil` otherwise**.
 
 # How to run your own slackify
+
 ## Initial Setup
+
 1. Install slackify in your app by adding the following line in your `Gemfile`:
 
 ```ruby
@@ -193,32 +203,32 @@ bundle install
 
 5. [Proceed to connect your bot to slack](#slack-setup)
 
-
 ## Slack Setup
+
 First, you'll need to create a new app on slack. Head over to [slack api](https://api.slack.com/apps) and create a new app.
 
 1. **Set Slack Secret Token**
 
-    In order to verify that the requets are coming from slack, we'll need to set the slack secret token in slackify. This value can be found as the signing secret in the app credentials section of the basic information page.
+   In order to verify that the requets are coming from slack, we'll need to set the slack secret token in slackify. This value can be found as the signing secret in the app credentials section of the basic information page.
 
 2. **Add a bot user**
-  
-    Under the feature section, click on "bot users". Pick a name for you slack bot and toggle on "Always Show My Bot as Online". Save the setting.
+
+   Under the feature section, click on "bot users". Pick a name for you slack bot and toggle on "Always Show My Bot as Online". Save the setting.
 
 3. **Enable events subscription**
 
-    Under the feature section, click "Events subscription". Turn the feature on and use your app url followed by `/slackify/event`. [Ngrok](https://ngrok.com/) can easily get you a public url if you are developing locally. The app needs to be running when you configure this url. After the url is configured, under the section "Subscribe to Bot Events", add the bot user event `message.im`.
+   Under the feature section, click "Events subscription". Turn the feature on and use your app url followed by `/slackify/event`. [Ngrok](https://ngrok.com/) can easily get you a public url if you are developing locally. The app needs to be running when you configure this url. After the url is configured, under the section "Subscribe to Bot Events", add the bot user event `message.im`.
 
 4. **Activate the interactive components**
-  
-    Under the feature section, click "interactive components". Turn the feature on and use your ngrok url followed by `/slackify/interactive`. Save the setting.
+
+   Under the feature section, click "interactive components". Turn the feature on and use your ngrok url followed by `/slackify/interactive`. Save the setting.
 
 5. **Install the App**
 
-    Under the setting section, click "install app" and proceed to install the app to the workspace. Once the app is installed, go back to the "install app" page and copy the Bot User OAuth Access Token.
+   Under the setting section, click "install app" and proceed to install the app to the workspace. Once the app is installed, go back to the "install app" page and copy the Bot User OAuth Access Token.
 
 6. **Configure Slackify**
-Add a new initializer with the following code
+   Add a new initializer with the following code
 
 ```ruby
 # config/initializers/slackify.rb
@@ -229,7 +239,7 @@ end
 ```
 
 7. **Define handlers specific subtypes** (Optional)
-You can set custom [message subtype](https://api.slack.com/events/message) handlers or custom [event type](https://api.slack.com/events) handlers inside your configuration
+   You can set custom [message subtype](https://api.slack.com/events/message) handlers or custom [event type](https://api.slack.com/events) handlers inside your configuration
 
 ```ruby
 # config/initializers/slackify.rb
@@ -248,7 +258,7 @@ end
 ```
 
 8. **Handle bot messages** (Highly optional)
-If you want your bot to accept other bot messages (which you probably should not do), you can. In the configuration step, you can set an array of whitelisted bot ids.
+   If you want your bot to accept other bot messages (which you probably should not do), you can. In the configuration step, you can set an array of whitelisted bot ids.
 
 ```ruby
 # config/initializers/slackify.rb
@@ -261,6 +271,6 @@ end
 
 **At this point, you are ready to go 😄**
 
-
 # LICENSE
+
 Copyright (c) 2019 Justin Léger, Michel Chatmajian. See [LICENSE](https://github.com/jusleg/slackify/blob/master/LICENSE) for further details.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We can rewrite the command above to
 
 And call the command with
 
-`/slackify repeat sentence="Why hullo there" times=10`
+`slackify repeat sentence="Why hullo there" times=10`
 
 This will supply a command arguments that are typed and coerced to the defined types:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ To add a new handler, you can add a new file under `app/handlers/` and start add
 
 **Note:** The regex supports [named capture](https://www.regular-expressions.info/named.html). In this example, we have a name example of `sentence`. When the handler command will be called, a key in the parameter hash will be added: `command_arguments`. This key will point to a hash of the capture name and value. In this case, `command_arguments => {sentence: "the sentence you wrote"}`
 
+### Handling messages with defined parameters
+
+The regular expression matching in the previous example provides a mechanism to supply named parameters to a method. However, many handlers may want to use named & typed parameters. This can be done using the `base_command` and `parameters` options.
+
+We can rewrite the command above to
+
+```yaml
+- repeat_handler:
+    commands:
+      - name: Repeat
+        description: "`repeat [sentence]`: Repeats the sentence you wrote"
+        base_command: "repeat"
+        parameters:
+          - sentence: string
+          - times: 10
+        action: repeat
+```
+
+And call the command with
+
+`/slackify repeat sentence="Why hullo there" times=10`
+
+This will supply a command arguments that are typed and coerced to the defined types:
+
+`command_arguments => {sentence: "Why hullo there", time: 10}`
+
 ### Handling interactive messages
 
 When sending an interactive message to a user, slack let's you define the `callback_id`. The app uses the callback id to select the proper handler for the message that was sent. The callback id must follow the given format: `class_name#method_name`. For instance if you set the callback id to `repeat_handler#repeat`, then `RepeatHandler#repeat` will be called. Adding new handlers does not require to update the `config/handlers.yml` configuration. You only need to update the callback id to define the proper handler to be used when you send an interactive message.

--- a/lib/slackify/handlers/base.rb
+++ b/lib/slackify/handlers/base.rb
@@ -22,7 +22,7 @@ module Slackify
         # needs to call a method on a supported handler and that handler needs
         # to explicitly specify which methods are for slash command.
         def allow_slash_method(element)
-          if @allowed_slash_methods
+          if defined?(@allowed_slash_methods) && @allowed_slash_methods
             @allowed_slash_methods.push(*element)
           else
             @allowed_slash_methods = Array(element)

--- a/lib/slackify/handlers/factory.rb
+++ b/lib/slackify/handlers/factory.rb
@@ -16,6 +16,8 @@ module Slackify
           built_command.regex = command['regex']
           built_command.handler = handler.name.camelize.constantize.method(command['action'])
           built_command.description = command['description']
+          built_command.parameters = command['parameters']
+          built_command.base_command = command['base_command']
           handler.commands << built_command.freeze
         end
 

--- a/lib/slackify/handlers/validator.rb
+++ b/lib/slackify/handlers/validator.rb
@@ -27,12 +27,12 @@ module Slackify
             if command['base_command'].present?
               command_errors.append('Regex and base_command cannot be used in the same handler.')
             end
-            
+
             if command['parameters'].present?
               command_errors.append('Regex and parameters cannot be used in the same handler.')
             end
           end
-          
+
           unless command['regex'].nil? || command['regex'].is_a?(Regexp)
             command_errors.append('No regex was provided.')
           end

--- a/lib/slackify/handlers/validator.rb
+++ b/lib/slackify/handlers/validator.rb
@@ -23,6 +23,16 @@ module Slackify
             command_errors.append('No regex or base command was provided.')
           end
 
+          if command['regex'].present?
+            if command['base_command'].present?
+              command_errors.append('Regex and base_command cannot be used in the same handler.')
+            end
+            
+            if command['parameters'].present?
+              command_errors.append('Regex and parameters cannot be used in the same handler.')
+            end
+          end
+          
           unless command['regex'].nil? || command['regex'].is_a?(Regexp)
             command_errors.append('No regex was provided.')
           end

--- a/lib/slackify/handlers/validator.rb
+++ b/lib/slackify/handlers/validator.rb
@@ -19,8 +19,16 @@ module Slackify
         handler.dig(handler_name, 'commands').each do |command|
           command_errors = []
 
-          unless command['regex'].is_a?(Regexp)
+          unless command['regex'] || command['base_command']
+            command_errors.append('No regex or base command was provided.')
+          end
+
+          unless command['regex'].nil? || command['regex'].is_a?(Regexp)
             command_errors.append('No regex was provided.')
+          end
+
+          unless command['base_command'].nil? || command['base_command'].is_a?(String)
+            command_errors.append('No base command was provided.')
           end
 
           unless !command['action'].to_s.strip.empty? && handler_class.respond_to?(command['action'])

--- a/lib/slackify/handlers/validator.rb
+++ b/lib/slackify/handlers/validator.rb
@@ -5,54 +5,77 @@ module Slackify
     # Simple validator for handlers. It will blow your app up on the
     # configuration step instead of crashing when handling production requests.
     class Validator
-      # Checks if your handler hash is valid. It's pass or raise 🧨💥
-      def self.verify_handler_integrity(handler)
-        handler_name = handler.keys.first
-        handler_class = handler_name.camelize.constantize
+      VALID_PARAMETER_TYPES = [:string, :int, :boolean, :float].freeze
 
-        unless handler[handler_name].key?('commands') && handler.dig(handler_name, 'commands')&.any?
-          raise Exceptions::InvalidHandler, "#{handler_name} doesn't have any command specified"
-        end
+      class << self
+        # Checks if your handler hash is valid. It's pass or raise 🧨💥
+        def verify_handler_integrity(handler)
+          handler_name = handler.keys.first
+          handler_class = handler_name.camelize.constantize
 
-        handler_errors = []
-
-        handler.dig(handler_name, 'commands').each do |command|
-          command_errors = []
-
-          unless command['regex'] || command['base_command']
-            command_errors.append('No regex or base command was provided.')
+          unless handler[handler_name].key?('commands') && handler.dig(handler_name, 'commands')&.any?
+            raise Exceptions::InvalidHandler, "#{handler_name} doesn't have any command specified"
           end
 
-          if command['regex'].present?
-            if command['base_command'].present?
-              command_errors.append('Regex and base_command cannot be used in the same handler.')
+          handler_errors = []
+
+          handler.dig(handler_name, 'commands').each do |command|
+            command_errors = []
+
+            unless command['regex'] || command['base_command']
+              command_errors.append('No regex or base command was provided.')
             end
 
-            if command['parameters'].present?
-              command_errors.append('Regex and parameters cannot be used in the same handler.')
+            if command['regex'].present?
+              if command['base_command'].present?
+                command_errors.append('Regex and base_command cannot be used in the same handler.')
+              end
+
+              if command['parameters'].present?
+                command_errors.append('Regex and parameters cannot be used in the same handler.')
+              end
+
+              unless command['regex'].is_a?(Regexp)
+                command_errors.append('No regex was provided.')
+              end
             end
+
+            if command['base_command']
+              unless command['base_command'].is_a?(String)
+                command_errors.append('Invalid base command provided, it must be a string.')
+              end
+
+              if command['parameters'].present?
+                command_errors << validate_parameters(command['parameters'])
+              end
+            end
+
+            unless !command['action'].to_s.strip.empty? && handler_class.respond_to?(command['action'])
+              command_errors.append('No valid action was provided.')
+            end
+            command_errors = command_errors.flatten.compact
+            handler_errors.append("[#{command['name']}]: #{command_errors.join(' ')}") unless command_errors.empty?
           end
 
-          unless command['regex'].nil? || command['regex'].is_a?(Regexp)
-            command_errors.append('No regex was provided.')
+          unless handler_errors.empty?
+            raise Exceptions::InvalidHandler, "#{handler_name} is not valid: #{handler_errors.join(' ')}"
           end
-
-          unless command['base_command'].nil? || command['base_command'].is_a?(String)
-            command_errors.append('No base command was provided.')
-          end
-
-          unless !command['action'].to_s.strip.empty? && handler_class.respond_to?(command['action'])
-            command_errors.append('No valid action was provided.')
-          end
-
-          handler_errors.append("[#{command['name']}]: #{command_errors.join(' ')}") unless command_errors.empty?
+        rescue NameError
+          raise Exceptions::InvalidHandler, "#{handler_name} is not defined"
         end
 
-        unless handler_errors.empty?
-          raise Exceptions::InvalidHandler, "#{handler_name} is not valid: #{handler_errors.join(' ')}"
+        def validate_parameters(parameters)
+          errors = []
+          parameters.each do |parameter|
+            key = parameter.keys[0]
+            type = parameter.values[0]
+
+            next if VALID_PARAMETER_TYPES.include?(type.to_sym)
+
+            errors << "Invalid parameter type for: #{key}, '#{type}'."
+          end
+          errors
         end
-      rescue NameError
-        raise Exceptions::InvalidHandler, "#{handler_name} is not defined"
       end
     end
   end

--- a/lib/slackify/router.rb
+++ b/lib/slackify/router.rb
@@ -11,7 +11,10 @@ module Slackify
 
       # Find the matching command based on the message string
       def matching_command(message)
-        all_commands.each { |command| return command if command.regex.match? message }
+        all_commands.each do |command|
+          return command if command.regex.present? && command.regex.match?(message)
+          return command if command.base_command.present? && message.start_with?(command.base_command)
+        end
         nil
       end
 
@@ -20,12 +23,74 @@ module Slackify
         command = matching_command(message)
         if command.nil?
           return unless Slackify.configuration.unhandled_handler
-
           Slackify.configuration.unhandled_handler.unhandled(params)
         else
-          new_params = params.merge(command_arguments: command.regex.match(message).named_captures)
+          new_params = params.merge({ command_arguments: extract_arguments(message, command) })
+
           command.handler.call(new_params)
         end
+      end
+
+      def extract_arguments(message, command)
+        if command.regex
+          command.regex.match(message).named_captures
+        else
+          raw_arguments = message.sub(/^#{command.base_command}/, '').strip
+          spec = {}
+          command.parameters.each do |parameter|
+            spec[parameter.keys[0].to_sym] = {type: parameter.values[0].to_sym}
+          end
+          parse_by_spec(spec, raw_arguments)
+        end
+      end
+
+      def parse_by_spec(spec, raw_arguments)
+        processed_args = {}
+
+        s = StringScanner.new(raw_arguments)
+        until s.eos?
+          # get the key, remove '=' and extra whitespace
+          current_key = s.scan_until(/=/)
+          break if current_key.nil?
+          current_key = current_key[0..-2].strip
+
+          # grab value accounting for any quotes
+          terminating_string = case s.peek(1)
+          when "'"
+            s.skip(/'/)
+            /'/
+          when '"'
+            s.skip(/"/)
+            /"/
+          else
+            / /
+          end
+          processed_args[current_key.to_sym] = if s.exist?(terminating_string)
+            # grab everything before the next instance of the terminating character
+            s.scan_until(terminating_string)[0..-2]
+          else
+            # this is probably wrong unless we were expecting a space, but hit eos
+            s.rest
+          end
+        end
+
+        # only pass on expected parameters for now.
+        processed_spec = {}
+        spec.each do |key, value|
+          # coerce to the expected type
+          processed_spec[key] = case value.fetch(:type, 'string')
+          when :int
+            processed_args[key].to_i
+          when :float
+            processed_args[key].to_f
+          when :bool
+            ActiveModel::Type::Boolean.new.cast(processed_args[key])
+          else
+            processed_args[key]
+          end
+        end
+
+        processed_spec
       end
     end
   end

--- a/lib/slackify/router.rb
+++ b/lib/slackify/router.rb
@@ -26,7 +26,7 @@ module Slackify
 
           Slackify.configuration.unhandled_handler.unhandled(params)
         else
-          new_params = params.merge({ command_arguments: extract_arguments(message, command) })
+          new_params = params.merge( command_arguments: extract_arguments(message, command) )
 
           command.handler.call(new_params)
         end

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails'
   s.add_dependency 'slack-ruby-client'
+  s.add_dependency 'strscan'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'

--- a/test/dummy/app/handlers/dummy_handler.rb
+++ b/test/dummy/app/handlers/dummy_handler.rb
@@ -36,5 +36,13 @@ class DummyHandler < Slackify::Handlers::Base
     def slash_command_not_permitted(_params)
       "this should never be called"
     end
+
+    def method_3_command(params)
+      puts "this takes args; "\
+        "int: #{params[:command_arguments][:integer_param]}, "\
+        "bool: #{params[:command_arguments][:bool_param]}, "\
+        "string: #{params[:command_arguments][:string_param]}, "\
+        "float: #{params[:command_arguments][:float_param]}"
+    end
   end
 end

--- a/test/dummy/config/handlers.yml
+++ b/test/dummy/config/handlers.yml
@@ -1,13 +1,19 @@
--  
-  dummy_handler:
+- dummy_handler:
     commands:
-      -
-        description: method 1
-        regex: !ruby/regexp '/wazza/'
+      - description: method 1
+        regex: !ruby/regexp "/^wazza/"
         action: cool_command
         name: method 1
-      -
-        description: method 2
-        regex: !ruby/regexp '/foo/'
+      - description: method 2
+        regex: !ruby/regexp "/^foo/"
         action: another_command
         name: method 2
+      - description: method 3 with args
+        base_command: "method3"
+        parameters:
+          - integer_param: int
+          - string_param: string
+          - float_param: float
+          - bool_param: boolean
+        action: method_3_command
+        name: method 3

--- a/test/integration/slack_controller_test.rb
+++ b/test/integration/slack_controller_test.rb
@@ -99,14 +99,14 @@ module Slackify
     test "#interactive_callback returns the proper following attachement" do
       # Setting up the Slack Ruby Client Mock
       options = { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
-      params = build_legacy_slack_interactive_callback(options)
+      params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
       assert_response :ok
 
       options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
-      params = build_legacy_slack_interactive_callback(options)
+      params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\" Button two has been clicked\"}]}", response.body
@@ -114,8 +114,8 @@ module Slackify
     end
 
     test "#interactive_callback raises error if the handler is not supported" do
-      options = { view: { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "random_handler#button_clicked" } }
-      params = build_slack_interactive_callback(options)
+      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "random_handler#button_clicked" }
+      params = build_slack_interactive_callback(**options)
 
       assert_raise Slackify::Exceptions::HandlerNotSupported do
         post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params

--- a/test/integration/slack_controller_test.rb
+++ b/test/integration/slack_controller_test.rb
@@ -82,14 +82,14 @@ module Slackify
     test "#interactive_callback returns the proper following blocks" do
       # Setting up the Slack Ruby Client Mock
       options = { view: { callback_id: "dummy_handler#button_clicked" }, actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }] }
-      params = build_slack_interactive_callback(options)
+      params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
       assert_response :ok
 
       options = { view: { callback_id: "dummy_handler#button_clicked" }, actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }] }
-      params = build_slack_interactive_callback(options)
+      params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\" Button two has been clicked\"}]}", response.body
@@ -98,14 +98,14 @@ module Slackify
 
     test "#interactive_callback returns the proper following attachement" do
       # Setting up the Slack Ruby Client Mock
-      options = { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      options = { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], view: { callback_id: "dummy_handler#button_clicked" } }
       params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
       assert_response :ok
 
-      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], view: { callback_id: "dummy_handler#button_clicked" } }
       params = build_slack_interactive_callback(**options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
@@ -114,7 +114,7 @@ module Slackify
     end
 
     test "#interactive_callback raises error if the handler is not supported" do
-      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "random_handler#button_clicked" }
+      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], view: { callback_id: "random_handler#button_clicked" } }
       params = build_slack_interactive_callback(**options)
 
       assert_raise Slackify::Exceptions::HandlerNotSupported do

--- a/test/unit/handlers/factory_test.rb
+++ b/test/unit/handlers/factory_test.rb
@@ -22,7 +22,7 @@ module Slackify
 
         handler_command = handler_struct.commands.first
 
-        assert_equal /wazza/, handler_command.regex
+        assert_equal(/wazza/, handler_command.regex)
         assert_equal 'A nice method', handler_command.description
         assert_equal DummyHandler.method(:cool_command), handler_command.handler
       end

--- a/test/unit/handlers/validator_test.rb
+++ b/test/unit/handlers/validator_test.rb
@@ -93,7 +93,7 @@ module Slackify
           "dummy_handler" => {
             "commands" => [{
               "description" => 'A nice method',
-              "action" => 'doesnt_exist',
+              "action" => 'cool_command',
               "name" => 'wazzzzzzaaa',
               "regex" => 123,
             }]
@@ -104,7 +104,7 @@ module Slackify
           Validator.verify_handler_integrity(handler_hash)
         end
         assert_equal(
-          "dummy_handler is not valid: [wazzzzzzaaa]: No regex was provided. No valid action was provided.",
+          "dummy_handler is not valid: [wazzzzzzaaa]: No regex was provided.",
           exception.message
         )
       end
@@ -114,7 +114,7 @@ module Slackify
           "dummy_handler" => {
             "commands" => [{
               "description" => 'A nice method',
-              "action" => 'doesnt_exist',
+              "action" => 'cool_command',
               "name" => 'wazzzzzzaaa',
               "base_command" => 123,
             }]
@@ -125,7 +125,51 @@ module Slackify
           Validator.verify_handler_integrity(handler_hash)
         end
         assert_equal(
-          "dummy_handler is not valid: [wazzzzzzaaa]: No base command was provided. No valid action was provided.",
+          "dummy_handler is not valid: [wazzzzzzaaa]: No base command was provided.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises conflict when regex and base_command is used" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'cool_command',
+              "name" => 'wazzzzzzaaa',
+              "base_command" => "foo",
+              "regex" => /wazza/,
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: Regex and base_command cannot be used in the same handler.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises conflict when regex and parameters is used" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'cool_command',
+              "name" => 'wazzzzzzaaa',
+              "parameters" => [{"integer_param"=> "int"}],
+              "regex" => /wazza/,
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: Regex and parameters cannot be used in the same handler.",
           exception.message
         )
       end

--- a/test/unit/handlers/validator_test.rb
+++ b/test/unit/handlers/validator_test.rb
@@ -159,7 +159,7 @@ module Slackify
               "description" => 'A nice method',
               "action" => 'cool_command',
               "name" => 'wazzzzzzaaa',
-              "parameters" => [{"integer_param"=> "int"}],
+              "parameters" => [{ "integer_param" => "int" }],
               "regex" => /wazza/,
             }]
           }

--- a/test/unit/handlers/validator_test.rb
+++ b/test/unit/handlers/validator_test.rb
@@ -125,7 +125,7 @@ module Slackify
           Validator.verify_handler_integrity(handler_hash)
         end
         assert_equal(
-          "dummy_handler is not valid: [wazzzzzzaaa]: No base command was provided.",
+          "dummy_handler is not valid: [wazzzzzzaaa]: Invalid base command provided, it must be a string.",
           exception.message
         )
       end
@@ -170,6 +170,28 @@ module Slackify
         end
         assert_equal(
           "dummy_handler is not valid: [wazzzzzzaaa]: Regex and parameters cannot be used in the same handler.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises error when parameter type is invalid" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'cool_command',
+              "name" => 'wazzzzzzaaa',
+              "base_command" => "foo",
+              "parameters" => [{ "integer_param" => "this_is_not_valid" }],
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: Invalid parameter type for: integer_param, 'this_is_not_valid'.",
           exception.message
         )
       end

--- a/test/unit/handlers/validator_test.rb
+++ b/test/unit/handlers/validator_test.rb
@@ -47,7 +47,7 @@ module Slackify
         exception = assert_raises(Exceptions::InvalidHandler) do
           Validator.verify_handler_integrity(handler_hash)
         end
-        assert_equal "dummy_handler is not valid: [wazzzzzzaaa]: No regex was provided.", exception.message
+        assert_equal "dummy_handler is not valid: [wazzzzzzaaa]: No regex or base command was provided.", exception.message
       end
 
       test "#verify_handler_integrity raises if the command doesn't have a valid action" do
@@ -82,8 +82,52 @@ module Slackify
         exception = assert_raises(Exceptions::InvalidHandler) do
           Validator.verify_handler_integrity(handler_hash)
         end
-        assert_equal "dummy_handler is not valid: [wazzzzzzaaa]: No regex was provided. No valid action was provided.",
-                     exception.message
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: No regex or base command was provided. No valid action was provided.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises invalid regex error" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'doesnt_exist',
+              "name" => 'wazzzzzzaaa',
+              "regex" => 123,
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: No regex was provided. No valid action was provided.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises invalid base command error" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'doesnt_exist',
+              "name" => 'wazzzzzzaaa',
+              "base_command" => 123,
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: No base command was provided. No valid action was provided.",
+          exception.message
+        )
       end
 
       test "#verify_handler_integrity raises if the handler doesn't exist" do

--- a/test/unit/router_test.rb
+++ b/test/unit/router_test.rb
@@ -12,6 +12,12 @@ module Slackify
       end
     end
 
+    test "parameters are parsed correctly" do
+      assert_output(/this takes args; int: 1, bool: false, string: foo, float: 0.2/) do
+        Slackify::Router.call_command('method3 integer_param=1 string_param=foo float_param=0.2 bool_param=false', {})
+      end
+    end
+
     test "Only one command gets called in the event of two regex match. Only the first match is called" do
       assert_output(/cool_command called/) do
         Slackify::Router.call_command('wazza foo', {})
@@ -24,8 +30,10 @@ module Slackify
     end
 
     test "#all_commands returns an array with all the commands" do
-      assert_equal ["method 1", "method 2"],
-                   ["method 1", "method 2"] & Slackify::Router.all_commands.each.collect(&:description)
+      assert_equal(
+        ["method 1", "method 2"],
+        ["method 1", "method 2"] & Slackify::Router.all_commands.each.collect(&:description)
+      )
     end
   end
 end


### PR DESCRIPTION
Based on the gist here: https://gist.github.com/yoshrote/f24f84c1e010a1296f1178849ef5ef34

I added support for named parameters in handlers, this doesn't handle un-named parameters being added, I'll add that in next since I feel there's still value in those.

The code tidying up was removing splat parameters, adding some parentheses, auto formatting the README and so on. The top commit is the real one that adds the base command functionality

```yaml
- repeat_handler:
    commands:
      - name: Repeat
        description: "`repeat [sentence]`: Repeats the sentence you wrote"
        base_command: "repeat"
        parameters:
          - sentence: string
          - times: 10
        action: repeat
```

Is added as an example in the README, I made it so that `regex` and `base_command` are mutually exclusive (we only use parameters if there's a base_command provided, ~but we ignore it otherwise, I'll add that next~)

EDIT: We now raise an error if `regex & base_command` are both provided, or `regex & parameters` are provided. That way there's no confusion