### PR TITLE
Update interactive handler to use new payload

### DIFF
--- a/app/controllers/slackify/slack_controller.rb
+++ b/app/controllers/slackify/slack_controller.rb
@@ -21,7 +21,8 @@ module Slackify
 
     def interactive_callback
       parsed_payload = JSON.parse(params[:payload])
-      response = handler_from_callback_id(parsed_payload["callback_id"]).call(parsed_payload)
+      view_data = parsed_payload['view']
+      response = handler_from_callback_id(view_data['callback_id']).call(parsed_payload)
       if !response.nil?
         Timeout.timeout(SLACK_TIMEOUT_SECONDS) do
           render json: response
@@ -30,7 +31,7 @@ module Slackify
         head :ok
       end
     rescue Timeout::Error
-      raise Timeout::Error, "Slack interactive callback timed out for #{parsed_payload['callback_id']}"
+      raise Timeout::Error, "Slack interactive callback timed out for #{view_data['callback_id']}"
     end
 
     def slash_command_callback

--- a/test/integration/slack_controller_test.rb
+++ b/test/integration/slack_controller_test.rb
@@ -79,17 +79,34 @@ module Slackify
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
     end
 
-    test "#interactive_callback returns the proper following attachement" do
+    test "#interactive_callback returns the proper following blocks" do
       # Setting up the Slack Ruby Client Mock
-      options = { view: { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" } }
+      options = { view: { callback_id: "dummy_handler#button_clicked" }, actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }] }
       params = build_slack_interactive_callback(options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
       assert_response :ok
 
-      options = { view: { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" } }
+      options = { view: { callback_id: "dummy_handler#button_clicked" }, actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }] }
       params = build_slack_interactive_callback(options)
+
+      post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
+      assert_equal "{\"attachments\":[{\"text\":\" Button two has been clicked\"}]}", response.body
+      assert_response :ok
+    end
+
+    test "#interactive_callback returns the proper following attachement" do
+      # Setting up the Slack Ruby Client Mock
+      options = { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      params = build_legacy_slack_interactive_callback(options)
+
+      post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
+      assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
+      assert_response :ok
+
+      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      params = build_legacy_slack_interactive_callback(options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\" Button two has been clicked\"}]}", response.body

--- a/test/integration/slack_controller_test.rb
+++ b/test/integration/slack_controller_test.rb
@@ -81,14 +81,14 @@ module Slackify
 
     test "#interactive_callback returns the proper following attachement" do
       # Setting up the Slack Ruby Client Mock
-      options = { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      options = { view: { actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }], callback_id: "dummy_handler#button_clicked" } }
       params = build_slack_interactive_callback(options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
       assert_equal "{\"attachments\":[{\"text\":\"Test\"}]}", response.body
       assert_response :ok
 
-      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" }
+      options = { view: { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "dummy_handler#button_clicked" } }
       params = build_slack_interactive_callback(options)
 
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
@@ -97,7 +97,7 @@ module Slackify
     end
 
     test "#interactive_callback raises error if the handler is not supported" do
-      options = { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "random_handler#button_clicked" }
+      options = { view: { actions: [{ "name" => "btn2", "value" => "btn2", "type" => "button" }], callback_id: "random_handler#button_clicked" } }
       params = build_slack_interactive_callback(options)
 
       assert_raise Slackify::Exceptions::HandlerNotSupported do

--- a/test/slack_test_helper.rb
+++ b/test/slack_test_helper.rb
@@ -37,14 +37,21 @@ module Slackify
       {
         payload: {
           type: "interactive_message",
-          actions: [
-            {
-              name: "btn1",
-              value: "btn1",
-              type: "button",
-            }
-          ],
-          callback_id: "dummy_handler#cool_command",
+          view: {
+            callback_id: "dummy_handler#cool_command",
+            type: 'modal',
+            title: {
+              type: 'plain_text',
+              text: 'Modal with inputs'
+            },
+            actions: [
+              {
+                name: "btn1",
+                value: "btn1",
+                type: "button",
+              }
+            ],
+          },
           team: {
             id: "TEAM1234",
             domain: "famingo",

--- a/test/slack_test_helper.rb
+++ b/test/slack_test_helper.rb
@@ -44,14 +44,14 @@ module Slackify
               type: 'plain_text',
               text: 'Modal with inputs'
             },
-            actions: [
-              {
-                name: "btn1",
-                value: "btn1",
-                type: "button",
-              }
-            ],
           },
+          actions: [
+            {
+              name: "btn1",
+              value: "btn1",
+              type: "button",
+            }
+          ],
           team: {
             id: "TEAM1234",
             domain: "famingo",
@@ -73,6 +73,41 @@ module Slackify
           },
           trigger_id: "13345224609.738474920.8088930838d88f008e0"
         }.deep_merge(options).to_json,
+      }
+    end
+
+    def build_legacy_slack_interactive_callback(**options)
+      {
+        payload: {
+          type: "interactive_message",
+          actions: [
+            {
+              name: "btn1",
+              value: "btn1",
+              type: "button",
+            }
+          ],
+          callback_id: "dummy_handler#cool_command",
+          team: {
+            id: "TEAM1234",
+            domain: "famingo",
+          },
+          channel: {
+            id: "CHANNEL1234",
+            name: "famingo-labs",
+          },
+          user: {
+            id: "USER1234",
+            name: "jusleg",
+          },
+          action_ts: "1458170917.164398",
+          message_ts: "1458170866.000004",
+          attachment_id: "1",
+          token: "testslacktoken123",
+          original_message: {
+          },
+          trigger_id: "13345224609.738474920.8088930838d88f008e0"
+        }.deep_merge(options).to_json
       }
     end
 


### PR DESCRIPTION
It looks like slack has changed how interactive payloads are formatted. They seem to now be wrapped in a `view` field.

Previously a callback from a `view_submission` would cause a `nil` when attempting to determine the callback handler.

Please see: https://api.slack.com/reference/interaction-payloads/views#view_submission