### PR TITLE
Add custom parameter parsing to Slackify

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Style/ClassVars:
   Enabled: true
   Exclude:
     - lib/slackify/handlers/base.rb
+    - lib/slackify/parameter.rb
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -4,6 +4,7 @@ require 'slackify/configuration'
 require 'slackify/engine'
 require 'slackify/exceptions'
 require 'slackify/handlers'
+require 'slackify/parameter'
 require 'slackify/router'
 
 module Slackify

--- a/lib/slackify/handlers/validator.rb
+++ b/lib/slackify/handlers/validator.rb
@@ -72,7 +72,13 @@ module Slackify
 
             next if VALID_PARAMETER_TYPES.include?(type.to_sym)
 
-            errors << "Invalid parameter type for: #{key}, '#{type}'."
+            type.constantize
+            next if Slackify::Parameter.supported_parameters.include?(type)
+
+            errors << "Invalid parameter type for: #{key}, '#{type}'.\n"\
+              "If this is a custom parameter, make sure it inherits from Slackify::Parameter"
+          rescue NameError
+            errors << "Failed to find the custom class for: #{key}, '#{type}'."
           end
           errors
         end

--- a/lib/slackify/parameter.rb
+++ b/lib/slackify/parameter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Slackify
+  # Base parameter class that any user defined parameters must inherit from
+  class Parameter
+    @@supported_parameters = []
+
+    class << self
+      # Any class inheriting from Slackify::Parameter will be added to
+      # the list of supported parameters
+      def inherited(subclass)
+        @@supported_parameters.push(subclass.to_s)
+      end
+
+      # Show a list of the parameters supported by the app. Since we do
+      # metaprogramming, we want to ensure we can only call defined parameter
+      def supported_parameters
+        @@supported_parameters
+      end
+    end
+  end
+end

--- a/lib/slackify/router.rb
+++ b/lib/slackify/router.rb
@@ -80,15 +80,18 @@ module Slackify
         processed_spec = {}
         spec.each do |key, value|
           # coerce to the expected type
-          processed_spec[key] = case value.fetch(:type, 'string')
+          type = value.fetch(:type, 'string')
+          processed_spec[key] = case type
                                 when :int
                                   processed_args[key].to_i
                                 when :float
                                   processed_args[key].to_f
-                                when :bool
+                                when :boolean
                                   ActiveModel::Type::Boolean.new.cast(processed_args[key])
-                                else
+                                when :string
                                   processed_args[key]
+                                else
+                                  Object.const_get(type).new(processed_args[key]).parse
                                 end
         end
 

--- a/test/dummy/app/handlers/dummy_handler.rb
+++ b/test/dummy/app/handlers/dummy_handler.rb
@@ -44,5 +44,10 @@ class DummyHandler < Slackify::Handlers::Base
         "string: #{params[:command_arguments][:string_param]}, "\
         "float: #{params[:command_arguments][:float_param]}"
     end
+
+    def method_4_command(params)
+      puts "this takes a user arg; "\
+        "user: #{params[:command_arguments][:user_param]}"
+    end
   end
 end

--- a/test/dummy/app/models/not_a_param.rb
+++ b/test/dummy/app/models/not_a_param.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NotAParam
+  def initialize(value)
+    @value = value
+  end
+
+  def parse
+    raise StandardError, "This should not be called."
+  end
+end

--- a/test/dummy/app/models/user_param.rb
+++ b/test/dummy/app/models/user_param.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UserParam < Slackify::Parameter
+  def initialize(value)
+    @value = value
+  end
+
+  def parse
+    if @value == 'W12345TG'
+      "Doug Edey"
+    else
+      "Foo"
+    end
+  end
+end

--- a/test/dummy/config/handlers.yml
+++ b/test/dummy/config/handlers.yml
@@ -17,3 +17,10 @@
           - bool_param: boolean
         action: method_3_command
         name: method 3
+
+      - description: method 4 with a custom parsed parameter
+        base_command: "method4"
+        parameters:
+          - user_param: UserParam
+        action: method_4_command
+        name: method 4

--- a/test/unit/handlers/validator_test.rb
+++ b/test/unit/handlers/validator_test.rb
@@ -191,7 +191,30 @@ module Slackify
           Validator.verify_handler_integrity(handler_hash)
         end
         assert_equal(
-          "dummy_handler is not valid: [wazzzzzzaaa]: Invalid parameter type for: integer_param, 'this_is_not_valid'.",
+          "dummy_handler is not valid: [wazzzzzzaaa]: Failed to find the custom class for: integer_param, 'this_is_not_valid'.",
+          exception.message
+        )
+      end
+
+      test "#verify_handler_integrity raises error when parameter class does not extend Slackify::Parameter" do
+        handler_hash = {
+          "dummy_handler" => {
+            "commands" => [{
+              "description" => 'A nice method',
+              "action" => 'cool_command',
+              "name" => 'wazzzzzzaaa',
+              "base_command" => "foo",
+              "parameters" => [{ "integer_param" => "NotAParam" }],
+            }]
+          }
+        }
+
+        exception = assert_raises(Exceptions::InvalidHandler) do
+          Validator.verify_handler_integrity(handler_hash)
+        end
+        assert_equal(
+          "dummy_handler is not valid: [wazzzzzzaaa]: Invalid parameter type for: integer_param, 'NotAParam'.\n"\
+            "If this is a custom parameter, make sure it inherits from Slackify::Parameter",
           exception.message
         )
       end

--- a/test/unit/router_test.rb
+++ b/test/unit/router_test.rb
@@ -18,6 +18,12 @@ module Slackify
       end
     end
 
+    test "parameters can be processed by a custom parser" do
+      assert_output(/this takes a user arg; user: Doug Edey/) do
+        Slackify::Router.call_command('method4 user_param=W12345TG', {})
+      end
+    end
+
     test "Only one command gets called in the event of two regex match. Only the first match is called" do
       assert_output(/cool_command called/) do
         Slackify::Router.call_command('wazza foo', {})


### PR DESCRIPTION
This is based on #12  so please just focus on the top commit (it's nice and small)

This allows Slackify to handle parameters that have classes as the type, originally I thought about doing it with a class method (`UserParam.parse(value)`)

But I worried that this would be a bit annoying to people integrating with slackify, so I went with a simple initializer and class attribute intention so that developers can make more custom parsers (such as looking up things externally and returning type errors - not handled yet)