### PR TITLE
Ensure that slack-ruby-client is above 0.15.1 for pagination of channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add support for named parameters in commands ([PR #12](https://github.com/jusleg/slackify/pull/12)) by [@DougEdey](https://github.com/DougEdey)
 - Add support for custom parameters in commands ([PR #17](https://github.com/jusleg/slackify/pull/17)) by [@DougEdey](https://github.com/DougEdey)
 - Tidy up some tests
+- Force slack-ruby-client to be version 0.15.1 or above to allow for pagination of Conversations
 
 ## V0.3.2
 

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency 'rails'
-  s.add_dependency 'slack-ruby-client'
+  s.add_dependency 'slack-ruby-client', '>= 0.15.1'
   s.add_dependency 'strscan'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Slack ruby client 0.15.1 fixed support for workspaces with over 100 channels: https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md#0151-202093