### PR TITLE
Add support for unicode magic quotes when parsing parameters

### DIFF
--- a/test/unit/router_test.rb
+++ b/test/unit/router_test.rb
@@ -18,6 +18,12 @@ module Slackify
       end
     end
 
+    test "parameters are parsed correctly with various quotes" do
+      assert_output(/this takes args; int: 1, bool: false, string: foo, float: 0.2/) do
+        Slackify::Router.call_command('method3 integer_param=\'1\' string_param="foo" float_param=“0.2” bool_param=false', {})
+      end
+    end
+
     test "parameters can be processed by a custom parser" do
       assert_output(/this takes a user arg; user: Doug Edey/) do
         Slackify::Router.call_command('method4 user_param=W12345TG', {})


### PR DESCRIPTION
When looking at this code I wrote, I figured I could tidy it up a bit.

The main issue I wanted to fix was to add magic quote support `“”`, these are unicode, so doing `StringScanner.peek(1)` only returned a single byte of that, but unicode can be anything up to 4 bytes (magic quotes are 3 bytes, but ascii single/double ones are 1 byte).

Then I realized we could use [getch](https://ruby-doc.org/stdlib-2.6.3/libdoc/strscan/rdoc/StringScanner.html#method-i-getch) and invert the `.skip(char)` with an `unscan` as StringScanner preserves our previous logic.

Then I wanted to get rid of the switch statement so it's easier to add new quotes in the future and it's a cleaner `if this exists in the hash, use it, otherwise use space` than the switch statement 