### PR TITLE
Stop freezing client

### DIFF
--- a/app/controllers/concerns/slack_token_verify.rb
+++ b/app/controllers/concerns/slack_token_verify.rb
@@ -26,8 +26,7 @@ module SlackTokenVerify
     end
 
     signature = "v0:#{timestamp}:#{request_body}"
-    calculated_hmac = "v0=" +
-                      OpenSSL::HMAC.hexdigest("sha256", Slackify.configuration.slack_secret_token, signature)
+    calculated_hmac = "v0=#{OpenSSL::HMAC.hexdigest('sha256', Slackify.configuration.slack_secret_token, signature)}"
 
     return if ActiveSupport::SecurityUtils.secure_compare(calculated_hmac, hmac_header)
 

--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -10,6 +10,7 @@ require 'slackify/router'
 module Slackify
   class << self
     attr_writer :configuration
+
     def configuration
       @configuration ||= Configuration.new
     end

--- a/lib/slackify/configuration.rb
+++ b/lib/slackify/configuration.rb
@@ -36,7 +36,7 @@ module Slackify
     # Set the token that we will use to connect to slack
     def slack_bot_token=(token)
       @slack_bot_token = token
-      @slack_client = Slack::Web::Client.new(token: token).freeze
+      @slack_client = Slack::Web::Client.new(token: token)
     end
 
     # Set a handler for a specific message subtype

--- a/lib/slackify/handlers/base.rb
+++ b/lib/slackify/handlers/base.rb
@@ -32,6 +32,7 @@ module Slackify
         # Any class inheriting from Slackify::Handler::Base will be added to
         # the list of supported handlers
         def inherited(subclass)
+          super
           @@supported_handlers.push(subclass.to_s)
         end
 

--- a/lib/slackify/parameter.rb
+++ b/lib/slackify/parameter.rb
@@ -9,6 +9,7 @@ module Slackify
       # Any class inheriting from Slackify::Parameter will be added to
       # the list of supported parameters
       def inherited(subclass)
+        super
         @@supported_parameters.push(subclass.to_s)
       end
 

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'slackify'
-  s.version     = '0.4.0'
+  s.version     = '0.4.1'
   s.date        = '2019-12-11'
   s.summary     = 'Slackbot framework for Rails using the Events API'
   s.description = 'Slackbot framework for Rails using the Events API. Supports events, interactive messages and slash commands.'

--- a/test/dummy/app/models/user_param.rb
+++ b/test/dummy/app/models/user_param.rb
@@ -2,6 +2,7 @@
 
 class UserParam < Slackify::Parameter
   def initialize(value)
+    super()
     @value = value
   end
 

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -6,16 +6,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/test/slack_test_helper.rb
+++ b/test/slack_test_helper.rb
@@ -113,8 +113,7 @@ module Slackify
 
     def build_webhook_headers(params, timestamp: Time.now, token: "123abcslacksecrettokenabc123")
       {
-        "X-Slack-Signature": "v0=" +
-          OpenSSL::HMAC.hexdigest("sha256", token, "v0:#{timestamp.to_i}:#{params.to_json}"),
+        "X-Slack-Signature": "v0=#{OpenSSL::HMAC.hexdigest('sha256', token, "v0:#{timestamp.to_i}:#{params.to_json}")}",
         "X-Slack-Request-Timestamp": timestamp.to_i,
       }
     end


### PR DESCRIPTION
When accessing the client we get errors that we can't modify a frozen class. This PR just removes the `.freeze`

```Slackify.configuration.slack_client.auth_test
FrozenError: can't modify frozen #<Class:#<Slack::Web::Client:0x00007fc77b9d4c58>>```