### PR TITLE
Adding support to handle block action id by interactive handler

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6 is
+    - name: Set up Ruby 3.1.3 is
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.1.3
     - uses: actions/cache@v1
       with:
         path: vendor/bundle

--- a/app/controllers/slackify/slack_controller.rb
+++ b/app/controllers/slackify/slack_controller.rb
@@ -21,16 +21,13 @@ module Slackify
 
     def interactive_callback
       parsed_payload = JSON.parse(params[:payload])
-      if parsed_payload['type'] == 'interactive_message'
-        callback_id = if parsed_payload.key?('view')
-                        parsed_payload.dig('view', 'callback_id')
-                      else
-                        parsed_payload['callback_id']
-                      end
-
-      elsif parsed_payload['type'] == 'block_actions'
-        callback_id = parsed_payload['actions'].first['action_id']
-      end
+      callback_id = if parsed_payload['type'] == 'block_actions'
+                      parsed_payload['actions'].first['action_id']
+                    elsif parsed_payload.key?('view')
+                      parsed_payload.dig('view', 'callback_id')
+                    else
+                      parsed_payload['callback_id']
+                    end
 
       response = handler_from_callback_id(callback_id).call(parsed_payload)
       if !response.nil?

--- a/app/controllers/slackify/slack_controller.rb
+++ b/app/controllers/slackify/slack_controller.rb
@@ -21,12 +21,16 @@ module Slackify
 
     def interactive_callback
       parsed_payload = JSON.parse(params[:payload])
+      if parsed_payload['type'] == 'interactive_message'
+        callback_id = if parsed_payload.key?('view')
+                        parsed_payload.dig('view', 'callback_id')
+                      else
+                        parsed_payload['callback_id']
+                      end
 
-      callback_id = if parsed_payload.key?('view')
-                      parsed_payload.dig('view', 'callback_id')
-                    else
-                      parsed_payload['callback_id']
-                    end
+      elsif parsed_payload['type'] == 'block_actions'
+        callback_id = parsed_payload['actions'].first['action_id']
+      end
 
       response = handler_from_callback_id(callback_id).call(parsed_payload)
       if !response.nil?

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'sprockets-rails'
 end

--- a/slackify.gemspec
+++ b/slackify.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'slackify'
-  s.version     = '0.4.2'
+  s.version     = '0.4.3'
   s.date        = '2019-12-11'
   s.summary     = 'Slackbot framework for Rails using the Events API'
   s.description = 'Slackbot framework for Rails using the Events API. Supports events, interactive messages and slash commands.'

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -16,8 +16,10 @@ require "slackify"
 
 module Dummy
   class Application < Rails::Application
+    load 'test/dummy/app/models/user_param.rb'
+    load 'test/dummy/app/handlers/dummy_handler.rb'
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    # config.load_defaults 5.2
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/test/integration/slack_controller_test.rb
+++ b/test/integration/slack_controller_test.rb
@@ -79,6 +79,12 @@ module Slackify
       post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
     end
 
+    test "#interactive_callback call the proper handler when action_id is sent" do
+      DummyHandler.expects(:cool_command).once
+      params = build_slack_interactive_action
+      post @interactive_callback_url, as: :json, headers: build_webhook_headers(params), params: params
+    end
+
     test "#interactive_callback returns the proper following blocks" do
       # Setting up the Slack Ruby Client Mock
       options = { view: { callback_id: "dummy_handler#button_clicked" }, actions: [{ "name" => "btn1", "value" => "btn1", "type" => "button" }] }

--- a/test/slack_test_helper.rb
+++ b/test/slack_test_helper.rb
@@ -76,6 +76,57 @@ module Slackify
       }
     end
 
+    def build_slack_interactive_action(**options)
+      {
+        payload: {
+          "type": "block_actions",
+          "user": {
+            "id": "USER_ID",
+            "username": "USERNAME",
+            "name": "USERNAME",
+            "team_id": "TEAM_ID"
+          },
+          "api_app_id": "API_APP_ID",
+          "token": "TOKEN",
+          "container": {
+            "type": "message",
+            "message_ts": "1674752364.004700",
+            "channel_id": "CHANNEL_ID",
+            "is_ephemeral": true
+          },
+          "trigger_id": "TRIGGER_ID",
+          "team": {
+            "id": "TEAM_ID",
+            "domain": "TEAM_DOMAIN"
+          },
+          "is_enterprise_install": false,
+          "channel": {
+            "id": "CHANNEL_ID",
+            "name": "CHANNEL_NAME"
+          },
+          "state": {
+            "values": {}
+          },
+          "response_url": "https://hooks.slack.com/actions/ABC/IJK/XYZ",
+          "actions": [
+            {
+              "action_id": "dummy_handler#cool_command",
+              "block_id": "BLOCK_ID",
+              "text": {
+                "type": "plain_text",
+                "text": "Click Me",
+                "emoji": true
+              },
+              "value": "click_me_123",
+              "style": "primary",
+              "type": "button",
+              "action_ts": "1674752368.385612"
+            }
+          ]
+        }.deep_merge(options).to_json,
+      }
+    end
+
     def build_legacy_slack_interactive_callback(**options)
       {
         payload: {


### PR DESCRIPTION
This PR should enable support for block actions referenced in #4 